### PR TITLE
connect関数を用いて、stateをpropsに渡すことをまとめた。

### DIFF
--- a/frontend/.eslintrc.cjs
+++ b/frontend/.eslintrc.cjs
@@ -5,15 +5,12 @@ module.exports = {
     'eslint:recommended',
     'plugin:@typescript-eslint/recommended',
     'plugin:react-hooks/recommended',
-    'prettier'
+    'prettier',
   ],
   ignorePatterns: ['dist', '.eslintrc.cjs'],
   parser: '@typescript-eslint/parser',
   plugins: ['react-refresh'],
   rules: {
-    'react-refresh/only-export-components': [
-      'warn',
-      { allowConstantExport: true },
-    ],
+    'react-refresh/only-export-components': ['off'],
   },
 }

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -14,8 +14,12 @@ const App = ({ countDayo, postsDayo }: AppComponentProps) => {
   )
 }
 
-const mapStateToProps = (state: arrayStateType) => {
-  return { countDayo: state.count, postsDayo: state.posts }
+const mapStateToProps = (state: any) => {
+  console.log(state)
+  return {
+    countDayo: state.countReducer.count,
+    postsDayo: state.postsReducer.posts,
+  }
 }
 
 export default connect(mapStateToProps)(App)

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -1,12 +1,15 @@
-import store from './store'
-
-const App = () => {
+import { connect } from 'react-redux'
+const App = ({ count }) => {
   return (
     <div>
       <h1>Redux Learn</h1>
-      <p>Count:{store.getState().count}</p>
+      <p>Count:{count}</p>
     </div>
   )
 }
 
-export default App
+const mapStateToProps = (state) => {
+  return { count: state.count }
+}
+
+export default connect(mapStateToProps)(App)

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -1,5 +1,6 @@
 import { connect } from 'react-redux'
-const App = ({ countDayo }) => {
+import type { countStateType, AppComponentProps } from './types/types'
+const App = ({ countDayo }: AppComponentProps) => {
   return (
     <div>
       <h1>Redux Learn</h1>
@@ -8,7 +9,7 @@ const App = ({ countDayo }) => {
   )
 }
 
-const mapStateToProps = (state) => {
+const mapStateToProps = (state: countStateType) => {
   return { countDayo: state.count }
 }
 

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -1,15 +1,15 @@
 import { connect } from 'react-redux'
-const App = ({ count }) => {
+const App = ({ countDayo }) => {
   return (
     <div>
       <h1>Redux Learn</h1>
-      <p>Count:{count}</p>
+      <p>Count:{countDayo}</p>
     </div>
   )
 }
 
 const mapStateToProps = (state) => {
-  return { count: state.count }
+  return { countDayo: state.count }
 }
 
 export default connect(mapStateToProps)(App)

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -1,16 +1,21 @@
 import { connect } from 'react-redux'
-import type { countStateType, AppComponentProps } from './types/types'
-const App = ({ countDayo }: AppComponentProps) => {
+import type { AppComponentProps, arrayStateType } from './types/types'
+const App = ({ countDayo, postsDayo }: AppComponentProps) => {
   return (
     <div>
       <h1>Redux Learn</h1>
       <p>Count:{countDayo}</p>
+      <ul>
+        {postsDayo.map((post) => (
+          <li key={post.id}>{post.title}</li>
+        ))}
+      </ul>
     </div>
   )
 }
 
-const mapStateToProps = (state: countStateType) => {
-  return { countDayo: state.count }
+const mapStateToProps = (state: arrayStateType) => {
+  return { countDayo: state.count, postsDayo: state.posts }
 }
 
 export default connect(mapStateToProps)(App)

--- a/frontend/src/store.ts
+++ b/frontend/src/store.ts
@@ -1,8 +1,11 @@
-import { legacy_createStore as createStore } from 'redux'
-import type { arrayStateType } from './types/types'
+import { legacy_createStore as createStore, combineReducers } from 'redux'
+import type { countStateType, postsStateType } from './types/types'
 // state
-const initialState: arrayStateType = {
-  count: 1,
+const countInitialState: countStateType = {
+  count: 50,
+}
+
+const postsInitialState: postsStateType = {
   posts: [
     { id: 1, title: 'title1' },
     { id: 2, title: 'title2' },
@@ -10,10 +13,14 @@ const initialState: arrayStateType = {
 }
 
 //reducer
-const reducer = (state: arrayStateType = initialState) => {
+const countReducer = (state = countInitialState) => {
   return state
 }
+const postsReducer = (state = postsInitialState) => {
+  return state
+}
+const rootReducer = combineReducers({ countReducer, postsReducer })
 
-const store = createStore(reducer)
+const store = createStore(rootReducer)
 
 export default store

--- a/frontend/src/store.ts
+++ b/frontend/src/store.ts
@@ -1,12 +1,16 @@
 import { legacy_createStore as createStore } from 'redux'
-import type { countStateType } from './types/types'
+import type { arrayStateType } from './types/types'
 // state
-const initialState: countStateType = {
+const initialState: arrayStateType = {
   count: 1,
+  posts: [
+    { id: 1, title: 'title1' },
+    { id: 2, title: 'title2' },
+  ],
 }
 
 //reducer
-const reducer = (state: countStateType = initialState) => {
+const reducer = (state: arrayStateType = initialState) => {
   return state
 }
 

--- a/frontend/src/store.ts
+++ b/frontend/src/store.ts
@@ -1,12 +1,12 @@
 import { legacy_createStore as createStore } from 'redux'
-
+import type { countStateType } from './types/types'
 // state
-const initialState = {
+const initialState: countStateType = {
   count: 1,
 }
 
 //reducer
-const reducer = (state = initialState) => {
+const reducer = (state: countStateType = initialState) => {
   return state
 }
 

--- a/frontend/src/types/types.ts
+++ b/frontend/src/types/types.ts
@@ -2,6 +2,13 @@ export type countStateType = {
   count: number
 }
 
+export type postsStateType = {
+  posts: {
+    id: number
+    title: string
+  }[]
+}
+
 export type arrayStateType = {
   count: number
   posts: {

--- a/frontend/src/types/types.ts
+++ b/frontend/src/types/types.ts
@@ -1,0 +1,7 @@
+export type countStateType = {
+  count: number
+}
+
+export type AppComponentProps = {
+  countDayo: number
+}

--- a/frontend/src/types/types.ts
+++ b/frontend/src/types/types.ts
@@ -2,6 +2,18 @@ export type countStateType = {
   count: number
 }
 
+export type arrayStateType = {
+  count: number
+  posts: {
+    id: number
+    title: string
+  }[]
+}
+
 export type AppComponentProps = {
   countDayo: number
+  postsDayo: {
+    id: number
+    title: string
+  }[]
 }


### PR DESCRIPTION
# reducerについて
reducerは最終的にcreateStore関数に渡す。
reducerは`(state=初期値のステート)=>{return ステート}`という構文
```ts
// state
const initialState: arrayStateType = {
  count: 1,
  posts: [
    { id: 1, title: 'title1' },
    { id: 2, title: 'title2' },
  ],
}

//reducer
const reducer = (state: arrayStateType = initialState) => {
  return state
}
```

# connect関数
connect関数を使うことによって、storeにあるstateを、コンポーネントがpropsで受け取ることができる

正しくは、「mapStateToProps関数ではstoreの中で設定したstateをAppコンポーネントにデータを渡せるpropsへと変換(map)しています。」なのかもしれないが、connectが実質、propsに変換する役割を持っているのではないか？
mapStateToPropsはconnect関数に渡すためのある種のおまじない的なものかもしれない。
```ts
const mapStateToProps = (state) => {
  return { 
                countDayo: state.count,  //←countDayoはのちにコンポーネントのpropsになるのでpropsにも同じものを書かなければならない
                postsDayo: state.posts
              }
}
```

そして最終的に、mapStateToPropsとコンポーネントをconnect関数に渡す。
```ts
export default connect(mapStateToProps)(App)
```

App.tsxでは特に、storeとかをインポートしたりしてないけど、connect関数が裏で繋いでくれてるのかもしれない。

# combineReducers

countとpostsそれぞれにreducerを定義して、combineReducersにまとめる。

```ts
const countReducer = (state = countInitialState) => {
  return state
}
const postsReducer = (state = postsInitialState) => {
  return state
}
const rootReducer = combineReducers({ countReducer, postsReducer })

const store = createStore(rootReducer)
```

stateを取り出すときは、
```ts
const mapStateToProps = (state: any) => {
  console.log(state)
  return {
    countDayo: state.countReducer.count,
    postsDayo: state.postsReducer.posts,
  }
}
```
で取り出せる