### PR TITLE
redux-thunkを使う

### DIFF
--- a/frontend/package.json
+++ b/frontend/package.json
@@ -13,7 +13,8 @@
     "react": "^18.2.0",
     "react-dom": "^18.2.0",
     "react-redux": "^9.1.2",
-    "redux": "^5.0.1"
+    "redux": "^5.0.1",
+    "redux-thunk": "^3.1.0"
   },
   "devDependencies": {
     "@types/react": "^18.2.66",

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -1,27 +1,21 @@
-import { connect } from 'react-redux'
-import type { AppComponentProps } from './types/types'
-import { increaseCount, decreaseCount } from './actions'
-import { useSelector, useDispatch } from 'react-redux'
+import { useState, useEffect } from 'react'
 const App = () => {
-  const countDayo = useSelector((state) => state.countReducer.count)
-  const postsDayo = useSelector((state) => state.postsReducer.posts)
-  const dispatch = useDispatch()
-  const increase = (amount) => {
-    dispatch(increaseCount(amount))
-  }
-  const decrease = (amount) => {
-    dispatch(decreaseCount(amount))
-  }
+  const [posts, setPosts] = useState([])
+
+  useEffect(() => {
+    const getPosts = async () => {
+      const res = await fetch('https://jsonplaceholder.typicode.com/posts')
+      const data = await res.json()
+      setPosts(data)
+    }
+    getPosts()
+  }, [])
+
   return (
     <div>
       <h1>Redux Learn</h1>
-      <p>Count:{countDayo}</p>
-      <button onClick={(e) => increase(1)}>+1</button>
-      <button onClick={(e) => increase(2)}>+2</button>
-      <button onClick={(e) => decrease(1)}>-1</button>
-      <button onClick={(e) => decrease(2)}>-2</button>
       <ul>
-        {postsDayo.map((post) => (
+        {posts.map((post) => (
           <li key={post.id}>{post.title}</li>
         ))}
       </ul>
@@ -29,17 +23,4 @@ const App = () => {
   )
 }
 
-const mapStateToProps = (state: any) => {
-  return {
-    _countDayo: state.countReducer.count,
-    _postsDayo: state.postsReducer.posts,
-  }
-}
-const mapDispatchToProps = (dispatch: any) => {
-  return {
-    _increase: (amount) => dispatch(increaseCount(amount)),
-    _decrease: (amount) => dispatch(decreaseCount(amount)),
-  }
-}
-
-export default connect(mapStateToProps, mapDispatchToProps)(App)
+export default App

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -1,15 +1,20 @@
-import { useState, useEffect } from 'react'
+import { useEffect } from 'react'
+import { useDispatch, useSelector } from 'react-redux'
 const App = () => {
-  const [posts, setPosts] = useState([])
+  const dispatch = useDispatch()
+  const posts = useSelector((state) => state.posts)
 
   useEffect(() => {
     const getPosts = async () => {
       const res = await fetch('https://jsonplaceholder.typicode.com/posts')
       const data = await res.json()
-      setPosts(data)
+      dispatch({
+        type: 'GET_POSTS_DATA',
+        payload: data,
+      })
     }
     getPosts()
-  }, [])
+  }, [dispatch])
 
   return (
     <div>

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -1,23 +1,15 @@
-import { useEffect } from 'react'
 import { useDispatch, useSelector } from 'react-redux'
+import { getPosts } from './actions'
 const App = () => {
   const dispatch = useDispatch()
   const posts = useSelector((state) => state.posts)
-  const getPosts = async () => {
-    const res = await fetch('https://jsonplaceholder.typicode.com/posts')
-    const data = await res.json()
-    dispatch({
-      type: 'GET_POSTS_DATA',
-      payload: data,
-    })
-  }
 
   return (
     <div>
       <h1>Redux Learn</h1>
       <button
         onClick={() => {
-          getPosts()
+          dispatch(getPosts())
         }}
       >
         fetchAll

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -3,22 +3,25 @@ import { useDispatch, useSelector } from 'react-redux'
 const App = () => {
   const dispatch = useDispatch()
   const posts = useSelector((state) => state.posts)
-
-  useEffect(() => {
-    const getPosts = async () => {
-      const res = await fetch('https://jsonplaceholder.typicode.com/posts')
-      const data = await res.json()
-      dispatch({
-        type: 'GET_POSTS_DATA',
-        payload: data,
-      })
-    }
-    getPosts()
-  }, [dispatch])
+  const getPosts = async () => {
+    const res = await fetch('https://jsonplaceholder.typicode.com/posts')
+    const data = await res.json()
+    dispatch({
+      type: 'GET_POSTS_DATA',
+      payload: data,
+    })
+  }
 
   return (
     <div>
       <h1>Redux Learn</h1>
+      <button
+        onClick={() => {
+          getPosts()
+        }}
+      >
+        fetchAll
+      </button>
       <ul>
         {posts.map((post) => (
           <li key={post.id}>{post.title}</li>

--- a/frontend/src/actions.ts
+++ b/frontend/src/actions.ts
@@ -1,10 +1,8 @@
-export const INCREASE_COUNT = '@@myapp/INCREASE_COUNT'
-export const DECREASE_COUNT = '@@myapp/DECREASE_COUNT'
-export const increaseCount = (amount) => ({
-  type: INCREASE_COUNT,
-  payload: amount,
-})
-export const decreaseCount = (amount) => ({
-  type: DECREASE_COUNT,
-  payload: amount,
-})
+export const getPosts = () => async (dispatch) => {
+  const res = await fetch('https://jsonplaceholder.typicode.com/posts')
+  const data = await res.json()
+  dispatch({
+    type: 'GET_POSTS_DATA',
+    payload: data,
+  })
+}

--- a/frontend/src/store.ts
+++ b/frontend/src/store.ts
@@ -1,4 +1,5 @@
-import { legacy_createStore as createStore } from 'redux'
+import { legacy_createStore as createStore, applyMiddleware } from 'redux'
+import { thunk } from 'redux-thunk'
 // state
 const initialState = {
   posts: [],
@@ -12,6 +13,6 @@ const reducer = (state = initialState, action) => {
       return state
   }
 }
-const store = createStore(reducer)
+const store = createStore(reducer, applyMiddleware(thunk))
 
 export default store

--- a/frontend/src/store.ts
+++ b/frontend/src/store.ts
@@ -1,38 +1,17 @@
-import { legacy_createStore as createStore, combineReducers } from 'redux'
-import type { countStateType, postsStateType } from './types/types'
-import { INCREASE_COUNT, DECREASE_COUNT } from './actions'
+import { legacy_createStore as createStore } from 'redux'
 // state
-const countInitialState: countStateType = {
-  count: 50,
+const initialState = {
+  posts: [],
 }
-
-const postsInitialState: postsStateType = {
-  posts: [
-    { id: 1, title: 'title1' },
-    { id: 2, title: 'title2' },
-  ],
-}
-
 //reducer
-const countReducer = (state = countInitialState, action) => {
+const reducer = (state = initialState, action) => {
   switch (action.type) {
-    case INCREASE_COUNT:
-      return {
-        count: state.count + action.payload,
-      }
-    case DECREASE_COUNT:
-      return {
-        count: state.count - action.payload,
-      }
+    case 'GET_POSTS_DATA':
+      return { ...state, posts: action.payload }
     default:
       return state
   }
 }
-const postsReducer = (state = postsInitialState) => {
-  return state
-}
-const rootReducer = combineReducers({ countReducer, postsReducer })
-
-const store = createStore(rootReducer)
+const store = createStore(reducer)
 
 export default store

--- a/frontend/yarn.lock
+++ b/frontend/yarn.lock
@@ -1205,6 +1205,11 @@ react@^18.2.0:
   dependencies:
     loose-envify "^1.1.0"
 
+redux-thunk@^3.1.0:
+  version "3.1.0"
+  resolved "https://registry.yarnpkg.com/redux-thunk/-/redux-thunk-3.1.0.tgz#94aa6e04977c30e14e892eae84978c1af6058ff3"
+  integrity sha512-NW2r5T6ksUKXCabzhL9z+h206HQw/NJkcLm1GPImRQ8IzfXwRGqjVhKJGauHirT0DAuyy6hjdnMZaRoAcy0Klw==
+
 redux@^4.0.0:
   version "4.2.1"
   resolved "https://registry.yarnpkg.com/redux/-/redux-4.2.1.tgz#c08f4306826c49b5e9dc901dee0452ea8fce6197"


### PR DESCRIPTION
# ReduxなしのAPI叩く

これでも記事データを取得できる（では、なぜreduxつかうん？）
```tsx
const App = () => {
  const [posts, setPosts] = useState([])

  useEffect(() => {
    const getPosts = async () => {
      const res = await fetch('https://jsonplaceholder.typicode.com/posts')
      const data = await res.json()
      setPosts(data)
    }
    getPosts()
  }, [])

  return (
    <div>
      <h1>Redux Learn</h1>
      <ul>
        {posts.map((post) => (
          <li key={post.id}>{post.title}</li>
        ))}
      </ul>
    </div>
  )
}
```

# redux-thunkを使わず、reduxだけを用いたAPI叩き

```ts
// store.ts
// state
const initialState = {
  posts: [],
}
//reducer
const reducer = (state = initialState, action) => {
  switch (action.type) {
    case 'GET_POSTS_DATA':
      return { ...state, posts: action.payload }
    default:
      return state
  }
}
const store = createStore(reducer)
```

```tsx
// App.tsx

  const dispatch = useDispatch()
  const posts = useSelector((state) => state.posts)

  useEffect(() => {
    const getPosts = async () => {
      const res = await fetch('https://jsonplaceholder.typicode.com/posts')
      const data = await res.json()
      dispatch({
        type: 'GET_POSTS_DATA',
        payload: data,
      })
    }
    getPosts()
  }, [dispatch])

  return (
    <div>
      <h1>Redux Learn</h1>
      <ul>
        {posts.map((post) => (
          <li key={post.id}>{post.title}</li>
        ))}
      </ul>
    </div>
  )
```

# Redux-thunkを使うメリット
https://qiita.com/hiroya8649/items/c202742c99d2cc6159b8
ここを参照。
とくに、userのログインとかの実装の時に使うのだと思う


# redux-thunkを使ったAPI叩き

redux-thunkを使った場合はdispatchにdispatch(actionCreator)を含む関数を渡すことができる。
構文で覚えてしまおう

まず、dispatchを引数にとり、さらに関数を返す関数をつくる（返す関数の中ではdipatch(actionObject)となるようにする）
```ts
export function fetchAll = () => {
  return dispatch => {
    dispatch({ type: actionTypes.FETCH_USERS})
    axios.get('/api/users').then(response => {
      dispatch({
        type: actionTypes.FETCH_USERS_SUCCESS,
        payload: response.data,
      })
    })
  }
}
```
fetchAll関数はstore.tsとかにも定義していいと思うが、なんか、actionを関数にすることがredux-thunkのメリットらしいのでfetchAllみたいな関数はactions.tsに書くのがいいと思う。

つぎに、dispatch関数の引数にfetchAllのような例のdispatchを引数に取り関数を返す関数を渡せばいい。
```tsx
export const TestPage: React.FC = () => {
  const dispatch = useDispatch()
  return (<button onClick={() => dispatch(fetchAll())}>Fetch</button>)
}
```